### PR TITLE
Removes hyperlinks from the post excerpt (pointed to FLD)

### DIFF
--- a/fontana.php
+++ b/fontana.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Fontana Regional Library
  * Plugin URI:        https://fontanalib.org
  * Description:       This is a short description of what the plugin does. It's displayed in the WordPress admin area.
- * Version:           1.9.7
+ * Version:           1.9.8
  * Author:            Michael Schofield
  * Author URI:        https://schoeyfield.com
  * GitHub Plugin URI: https://github.com/fontana-regional-library/big-kahuna

--- a/includes/class-fontana.php
+++ b/includes/class-fontana.php
@@ -218,6 +218,7 @@ class Fontana {
 		$this->loader->add_action( 'rest_api_init', $plugin_public, 'register_images_field' );
     $this->loader->add_filter( 'tribe_rest_event_data', $plugin_public, 'add_tribe_event_data', 10, 2 );
     $this->loader->add_filter( 'rest_collection-item_query',$plugin_public, 'collection_api_newest',10, 2 );
+    $this->loader->add_filter( 'excerpt_more',$plugin_public, 'remove_read_more', 11);
 		
 		// Register hooks related to custom events api
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-fontana-events-api.php';

--- a/public/class-fontana-public.php
+++ b/public/class-fontana-public.php
@@ -235,5 +235,11 @@ class Fontana_Public {
 
 		$args['meta_query'] = $meta_query; 
 		return $args;
-	}
+  }
+  /**
+   * Removes the "continue reading" links from post excerpts.
+   */
+  function remove_read_more($more){
+    return;
+  }
 }


### PR DESCRIPTION
ends with ellipses rather than "continue reading" hyperlink (posts, pages, ??)